### PR TITLE
Update tools_calibrate.py for use of dual gantry

### DIFF
--- a/klipper/extras/tools_calibrate.py
+++ b/klipper/extras/tools_calibrate.py
@@ -344,6 +344,7 @@ class ProbeEndstopWrapper:
         self.printer = config.get_printer()
         self.axis = axis
         self.idex = config.has_section('dual_carriage')
+        self.dual_gantry = (config.getsection('printer').get('kinematics') == 'dualgantry_corexy')
         # Create an "endstop" object to handle the probe pin
         ppins = self.printer.lookup_object('pins')
         pin = config.get('pin')
@@ -366,6 +367,12 @@ class ProbeEndstopWrapper:
             dual_carriage = self.printer.lookup_object('dual_carriage')
             prime_rail = dual_carriage.get_primary_rail()
             return prime_rail.get_rail().get_steppers()
+        elif self.dual_gantry == True and self.axis == 'x':
+            kin = self.printer.lookup_object('toolhead').get_kinematics()
+            return kin.dualgantry_rails[kin.active_carriage][0].get_steppers()
+        elif self.dual_gantry == True and self.axis == 'y':
+            kin = self.printer.lookup_object('toolhead').get_kinematics()
+            return kin.dualgantry_rails[kin.active_carriage][1].get_steppers()
         else:
             return self.mcu_endstop.get_steppers()
 


### PR DESCRIPTION
Added detection of been used on a dual gantry printer  ( i.e. D0), based on configured printer.kineamatics ==  dualgantry_corexy.  Added the return of the currently used steppers to prevent the error "Probe triggered before movement".